### PR TITLE
New ProductShippingDto instead of CarloadDto

### DIFF
--- a/goods-partner-backend/src/main/java/com/goodspartner/dto/DeliveryDto.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/dto/DeliveryDto.java
@@ -24,5 +24,5 @@ public class DeliveryDto {
 
     private List<RouteDto> routes;
     private List<OrderDto> orders;
-    private List<CarLoadDto> carLoads;
+    private List<ProductShippingDto> productsShipping;
 }

--- a/goods-partner-backend/src/main/java/com/goodspartner/dto/ProductLoadDto.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/dto/ProductLoadDto.java
@@ -1,0 +1,20 @@
+package com.goodspartner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ProductLoadDto {
+    private String orderNumber;
+    private String car;
+    private int amount;
+    private double weight;
+    private double totalWeight;
+}

--- a/goods-partner-backend/src/main/java/com/goodspartner/dto/ProductShippingDto.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/dto/ProductShippingDto.java
@@ -1,0 +1,21 @@
+package com.goodspartner.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ProductShippingDto {
+    private String article;
+    private int totalAmount;
+    private double totalWeight;
+    private List<ProductLoadDto> productLoadDtos;
+}

--- a/goods-partner-backend/src/main/java/com/goodspartner/entity/CarLoad.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/entity/CarLoad.java
@@ -5,11 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
 
 import javax.persistence.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @AllArgsConstructor
 @NoArgsConstructor

--- a/goods-partner-backend/src/main/java/com/goodspartner/mapper/DeliveryMapper.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/mapper/DeliveryMapper.java
@@ -10,7 +10,7 @@ import org.mapstruct.MappingTarget;
 import java.util.List;
 
 @Mapper(componentModel = "spring",
-        uses = {RouteMapper.class, OrderExternalMapper.class, CarLoadMapper.class})
+        uses = {RouteMapper.class, OrderExternalMapper.class, ProductShippingMapper.class})
 public interface DeliveryMapper {
 
     @Mapping(target = "id", ignore = true)
@@ -21,11 +21,13 @@ public interface DeliveryMapper {
 
     @Mapping(target = "routes", ignore = true)
     @Mapping(target = "orders", ignore = true)
-    @Mapping(target = "carLoads", ignore = true)
+    @Mapping(target = "productsShipping", ignore = true)
     DeliveryDto toDeliveryDtoResult(@MappingTarget DeliveryDto deliveryDto, Delivery delivery);
 
+    @Mapping(target = "productsShipping", source = "carLoads")
     DeliveryDto deliveryToDeliveryDto(Delivery delivery);
 
+    @Mapping(target = "carLoads", ignore = true)
     Delivery deliveryDtoToDelivery(DeliveryDto deliveryDto);
 
     List<DeliveryDto> deliveriesToDeliveryDtos(List<Delivery> deliveries);

--- a/goods-partner-backend/src/main/java/com/goodspartner/mapper/DeliveryRouteMapper.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/mapper/DeliveryRouteMapper.java
@@ -15,7 +15,7 @@ public interface DeliveryRouteMapper {
     List<DeliveryDto> mapDeliveriesWithRoutes(List<Delivery> deliveries);
 
     @Mapping(target = "orders", ignore = true)
-    @Mapping(target = "carLoads", ignore = true)
+    @Mapping(target = "productsShipping", ignore = true)
     DeliveryDto mapDeliveryWithRoute(Delivery delivery);
 
 }

--- a/goods-partner-backend/src/main/java/com/goodspartner/mapper/ProductShippingMapper.java
+++ b/goods-partner-backend/src/main/java/com/goodspartner/mapper/ProductShippingMapper.java
@@ -1,0 +1,70 @@
+package com.goodspartner.mapper;
+
+import com.goodspartner.dto.ProductLoadDto;
+import com.goodspartner.dto.ProductShippingDto;
+import com.goodspartner.entity.Car;
+import com.goodspartner.entity.CarLoad;
+import com.google.common.annotations.VisibleForTesting;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+@Component
+public class ProductShippingMapper {
+
+    public List<ProductShippingDto> getCarloadByProduct(List<CarLoad> carLoads) {
+        if (carLoads == null) {
+            return null;
+        }
+
+        Map<String, List<ProductLoadDto>> shippingProductMap = getProductLoadMap(carLoads);
+
+        return getProductShippingList(shippingProductMap);
+    }
+
+    @VisibleForTesting
+    Map<String, List<ProductLoadDto>> getProductLoadMap(List<CarLoad> carLoads) {
+        return carLoads.stream()
+                .flatMap(carLoad -> carLoad.getOrders().stream()
+                        .flatMap(orderExternal -> orderExternal.getProducts().stream()
+                                .map(product -> Pair.of(product.getProductName(), new ProductLoadDto(
+                                        orderExternal.getOrderNumber(),
+                                        this.getCarNameAndLicencePlate(carLoad.getCar()),
+                                        product.getAmount(),
+                                        product.getUnitWeight(),
+                                        product.getTotalProductWeight()))
+                                )
+                        )
+                )
+                .collect(groupingBy(Pair::getFirst, mapping(Pair::getSecond, toList())));
+    }
+
+    @VisibleForTesting
+    List<ProductShippingDto> getProductShippingList(Map<String, List<ProductLoadDto>> shippingProductMap) {
+        List<ProductShippingDto> productShippingDtos = new ArrayList<>(1);
+        for (Map.Entry<String, List<ProductLoadDto>> entry : shippingProductMap.entrySet()) {
+            String article = entry.getKey();
+            int amount = 0;
+            double weight = 0;
+            for (ProductLoadDto productLoadDto : entry.getValue()) {
+                amount += productLoadDto.getAmount();
+                weight += productLoadDto.getTotalWeight();
+            }
+            productShippingDtos.add(new ProductShippingDto(article, amount, weight, entry.getValue()));
+        }
+
+        return productShippingDtos;
+    }
+
+    @VisibleForTesting
+    String getCarNameAndLicencePlate(Car car) {
+        return String.format("%s (%s)", car.getName(), car.getLicencePlate());
+    }
+}

--- a/goods-partner-backend/src/test/java/com/goodspartner/mapper/DeliveryMapperTest.java
+++ b/goods-partner-backend/src/test/java/com/goodspartner/mapper/DeliveryMapperTest.java
@@ -1,19 +1,14 @@
 package com.goodspartner.mapper;
 
 import com.goodspartner.dto.DeliveryDto;
-import com.goodspartner.entity.Car;
-import com.goodspartner.entity.CarLoad;
 import com.goodspartner.entity.Delivery;
 import com.goodspartner.entity.DeliveryStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,7 +19,8 @@ import static org.junit.jupiter.api.Assertions.*;
         CarLoadMapperImpl.class,
         CarMapperImpl.class,
         OrderExternalMapperImpl.class,
-        RouteMapperImpl.class
+        RouteMapperImpl.class,
+        ProductShippingMapper.class
 })
 public class DeliveryMapperTest {
 
@@ -40,7 +36,7 @@ public class DeliveryMapperTest {
                 .deliveryDate(LocalDate.of(2022, 8, 15))
                 .routes(null)
                 .orders(null)
-                .carLoads(null)
+                .productsShipping(null)
                 .status(DeliveryStatus.COMPLETED)
                 .build();
 

--- a/goods-partner-backend/src/test/java/com/goodspartner/mapper/ProductShippingMapperTest.java
+++ b/goods-partner-backend/src/test/java/com/goodspartner/mapper/ProductShippingMapperTest.java
@@ -1,0 +1,121 @@
+package com.goodspartner.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.goodspartner.dto.ProductLoadDto;
+import com.goodspartner.dto.ProductShippingDto;
+import com.goodspartner.entity.Car;
+import com.goodspartner.entity.CarLoad;
+import com.goodspartner.entity.OrderExternal;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+class ProductShippingMapperTest {
+
+    private static final String MOCK_ORDERS_PATH = "datasets/common/product_shipping/orders.json";
+    private static final String MOCK_CARS_PATH = "datasets/common/product_shipping/cars.json";
+    private static final String MOCK_PRODUCT_SHIPPING_PATH = "datasets/common/product_shipping/expected_product_shipping_list.json";
+
+    private final ProductShippingMapper productShippingMapper = new ProductShippingMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private List<CarLoad> carLoads;
+    private Car car;
+    private Map<String, List<ProductLoadDto>> productMap;
+    private List<ProductShippingDto> expectedProductShipping;
+
+    @BeforeAll
+    void before() throws IOException {
+        objectMapper.registerModule(new JavaTimeModule());
+
+        List<OrderExternal> orders = Arrays.asList(
+                objectMapper.readValue(getResponseAsString(MOCK_ORDERS_PATH), OrderExternal[].class));
+        List<Car> cars = Arrays.asList(
+                objectMapper.readValue(getResponseAsString(MOCK_CARS_PATH), Car[].class));
+        expectedProductShipping = Arrays.asList(
+                objectMapper.readValue(getResponseAsString(MOCK_PRODUCT_SHIPPING_PATH), ProductShippingDto[].class));
+
+        carLoads = List.of(
+                new CarLoad(null, cars.get(0), orders, null),
+                new CarLoad(null, cars.get(1), orders, null)
+        );
+        car = cars.get(1);
+
+        List<ProductLoadDto> flour = List.of(
+                new ProductLoadDto("986453", "Mercedes Vito (AA 2222 CT)", 9, 50, 450),
+                new ProductLoadDto("986453", "Mercedes Sprinter (AA 3333 CT)", 9, 50, 450)
+        );
+        List<ProductLoadDto> dye = List.of(
+                new ProductLoadDto("432565", "Mercedes Vito (AA 2222 CT)", 5, 10, 50),
+                new ProductLoadDto("426457", "Mercedes Vito (AA 2222 CT)", 10, 10, 100),
+                new ProductLoadDto("432565", "Mercedes Sprinter (AA 3333 CT)", 5, 10, 50),
+                new ProductLoadDto("426457", "Mercedes Sprinter (AA 3333 CT)", 10, 10, 100)
+        );
+        List<ProductLoadDto> oil = List.of(
+                new ProductLoadDto("432565", "Mercedes Vito (AA 2222 CT)", 10, 25, 250),
+                new ProductLoadDto("986453", "Mercedes Vito (AA 2222 CT)", 1, 25, 25),
+                new ProductLoadDto("432565", "Mercedes Sprinter (AA 3333 CT)", 10, 25, 250),
+                new ProductLoadDto("986453", "Mercedes Sprinter (AA 3333 CT)", 1, 25, 25)
+        );
+
+        productMap = Map.of(
+                "8795 Мука екстра", flour,
+                "4695 Фарба харчова зелена", dye,
+                "8452 Масло 1й гатунок", oil
+        );
+
+    }
+
+    @Test
+    void testGetCarloadByProduct() {
+        List<ProductShippingDto> actualProductShipping = productShippingMapper.getCarloadByProduct(carLoads);
+
+        assertEquals(expectedProductShipping, actualProductShipping);
+
+    }
+
+    @Test
+    void testGetProductLoadMap() {
+        Map<String, List<ProductLoadDto>> actualProductLoadMap = productShippingMapper.getProductLoadMap(carLoads);
+
+        assertTrue(productMap.equals(actualProductLoadMap));
+    }
+
+    @Test
+    void testGetProductShippingList() {
+        List<ProductShippingDto> actualProductShipping = productShippingMapper.getProductShippingList(productMap);
+
+        assertTrue(CollectionUtils.isEqualCollection(expectedProductShipping, actualProductShipping));
+    }
+
+    @Test
+    void testGetCarNameAndLicencePlate() {
+        String carNameAndLicencePlate = productShippingMapper.getCarNameAndLicencePlate(car);
+        assertEquals("Mercedes Sprinter (AA 3333 CT)", carNameAndLicencePlate);
+    }
+
+    private String getResponseAsString(String jsonPath) {
+        URL resource = getClass().getClassLoader().getResource(jsonPath);
+        try {
+            return FileUtils.readFileToString(new File(resource.toURI()), StandardCharsets.UTF_8);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException("Unable to find file: " + jsonPath);
+        }
+    }
+}

--- a/goods-partner-backend/src/test/resources/datasets/common/delivery/calculate/deliveryDto.json
+++ b/goods-partner-backend/src/test/resources/datasets/common/delivery/calculate/deliveryDto.json
@@ -132,71 +132,32 @@
       "orderWeight": 1500.0
     }
   ],
-  "carLoads": [
+  "productsShipping": [
     {
-      "car": {
-        "id": 151,
-        "name": "Mercedes Sprinter",
-        "licencePlate": "AA 3333 CT",
-        "driver": "Anton Geraschenko",
-        "weightCapacity": 2500,
-        "cooler": true,
-        "available": true,
-        "loadSize": 2499.0,
-        "travelCost": 15
-      },
-      "orders": [
+      "article": "271008240 Тарілка Камінь Сіра 24*24 (80 шт) 271/24",
+      "totalAmount": 1,
+      "totalWeight": 999.0,
+      "productLoadDtos": [
         {
-          "id": 151,
-          "refKey": "b5619e6b-8d72-11ec-b3ce-00155dd72305",
           "orderNumber": "00000003433",
-          "createdDate": "2022-02-14",
-          "comment": null,
-          "managerFullName": "Крамаренко Леся                                   ",
-          "clientName": "Новус Україна ТОВ",
-          "address": "м.Київ провулок Політехнічний 1/33",
-          "mapPoint": {
-            "address": "м.Київ провулок Політехнічний 1/33",
-            "latitude": 50.4504636,
-            "longitude": 30.4667037,
-            "status": "KNOWN"
-          },
-          "products": [
-            {
-              "productName": "271008240 Тарілка Камінь Сіра 24*24 (80 шт) 271/24",
-              "amount": 1,
-              "storeName": "Склад №1",
-              "unitWeight": 8.0,
-              "totalProductWeight": 999.0
-            }
-          ],
-          "orderWeight": 999.0
-        },
+          "car": "Mercedes Sprinter (AA 3333 CT)",
+          "amount": 1,
+          "weight": 8.0,
+          "totalWeight": 999.0
+        }
+      ]
+    },
+    {
+      "article": "715050B Форми тюльпани 150/50 Коричневі (3200 шт)",
+      "totalAmount": 1,
+      "totalWeight": 1500.0,
+      "productLoadDtos": [
         {
-          "id": 201,
-          "refKey": "18ee46a5-8e41-11ec-b3ce-00155dd72305",
           "orderNumber": "00000003639",
-          "createdDate": "2022-02-15",
-          "comment": null,
-          "managerFullName": "Крамаренко Леся                                   ",
-          "clientName": "Новус Україна ТОВ",
-          "address": "м.Київ, пр. Академіка Палладіна, 7-А",
-          "mapPoint": {
-            "address": "м.Київ, пр. Академіка Палладіна, 7-А",
-            "latitude": 50.4618259,
-            "longitude": 30.3553835,
-            "status": "KNOWN"
-          },
-          "products": [
-            {
-              "productName": "715050B Форми тюльпани 150/50 Коричневі (3200 шт)",
-              "amount": 1,
-              "storeName": "Склад №1",
-              "unitWeight": 3200.0,
-              "totalProductWeight": 1500.0
-            }
-          ],
-          "orderWeight": 1500.0
+          "car": "Mercedes Sprinter (AA 3333 CT)",
+          "amount": 1,
+          "weight": 3200.0,
+          "totalWeight": 1500.0
         }
       ]
     }

--- a/goods-partner-backend/src/test/resources/datasets/common/product_shipping/cars.json
+++ b/goods-partner-backend/src/test/resources/datasets/common/product_shipping/cars.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 101,
+    "name": "Mercedes Vito",
+    "licencePlate": "AA 2222 CT",
+    "driver": "Ivan Piddubny",
+    "weightCapacity": 1000,
+    "cooler": false,
+    "available": true,
+    "travelCost": 10
+  },
+  {
+    "id": 151,
+    "name": "Mercedes Sprinter",
+    "licencePlate": "AA 3333 CT",
+    "driver": "Anton Geraschenko",
+    "weightCapacity": 2500,
+    "cooler": true,
+    "available": true,
+    "travelCost": 15
+  }
+]

--- a/goods-partner-backend/src/test/resources/datasets/common/product_shipping/expected_product_shipping_list.json
+++ b/goods-partner-backend/src/test/resources/datasets/common/product_shipping/expected_product_shipping_list.json
@@ -1,0 +1,93 @@
+[
+  {
+    "article": "8795 Мука екстра",
+    "totalAmount": 18,
+    "totalWeight": 900.0,
+    "productLoadDtos": [
+      {
+        "orderNumber": "986453",
+        "car": "Mercedes Vito (AA 2222 CT)",
+        "amount": 9,
+        "weight": 50.0,
+        "totalWeight": 450.0
+      },
+      {
+        "orderNumber": "986453",
+        "car": "Mercedes Sprinter (AA 3333 CT)",
+        "amount": 9,
+        "weight": 50.0,
+        "totalWeight": 450.0
+      }
+    ]
+  },
+  {
+    "article": "4695 Фарба харчова зелена",
+    "totalAmount": 30,
+    "totalWeight": 300.0,
+    "productLoadDtos": [
+      {
+        "orderNumber": "432565",
+        "car": "Mercedes Vito (AA 2222 CT)",
+        "amount": 5,
+        "weight": 10.0,
+        "totalWeight": 50.0
+      },
+      {
+        "orderNumber": "426457",
+        "car": "Mercedes Vito (AA 2222 CT)",
+        "amount": 10,
+        "weight": 10.0,
+        "totalWeight": 100.0
+      },
+      {
+        "orderNumber": "432565",
+        "car": "Mercedes Sprinter (AA 3333 CT)",
+        "amount": 5,
+        "weight": 10.0,
+        "totalWeight": 50.0
+      },
+      {
+        "orderNumber": "426457",
+        "car": "Mercedes Sprinter (AA 3333 CT)",
+        "amount": 10,
+        "weight": 10.0,
+        "totalWeight": 100.0
+      }
+    ]
+  },
+  {
+    "article": "8452 Масло 1й гатунок",
+    "totalAmount": 22,
+    "totalWeight": 550.0,
+    "productLoadDtos": [
+      {
+        "orderNumber": "432565",
+        "car": "Mercedes Vito (AA 2222 CT)",
+        "amount": 10,
+        "weight": 25.0,
+        "totalWeight": 250.0
+      },
+      {
+        "orderNumber": "986453",
+        "car": "Mercedes Vito (AA 2222 CT)",
+        "amount": 1,
+        "weight": 25.0,
+        "totalWeight": 25.0
+      },
+      {
+        "orderNumber": "432565",
+        "car": "Mercedes Sprinter (AA 3333 CT)",
+        "amount": 10,
+        "weight": 25.0,
+        "totalWeight": 250.0
+      },
+      {
+        "orderNumber": "986453",
+        "car": "Mercedes Sprinter (AA 3333 CT)",
+        "amount": 1,
+        "weight": 25.0,
+        "totalWeight": 25.0
+      }
+    ]
+  }
+]

--- a/goods-partner-backend/src/test/resources/datasets/common/product_shipping/orders.json
+++ b/goods-partner-backend/src/test/resources/datasets/common/product_shipping/orders.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": 1,
+    "refKey": "02grande-0000-0000-0000-000000000000",
+    "orderNumber": "432565",
+    "products": [
+      {
+        "productName": "4695 Фарба харчова зелена",
+        "amount": 5,
+        "storeName": "Склад №1",
+        "unitWeight": 10.00,
+        "totalProductWeight": 50.00
+      },
+      {
+        "productName": "8452 Масло 1й гатунок",
+        "amount": 10,
+        "storeName": "Склад №1",
+        "unitWeight": 25.00,
+        "totalProductWeight": 250.00
+      }
+    ],
+    "addressExternal": {
+      "orderAddressId": {
+        "orderAddress": "м. Київ, вул. Хрещатик, 1",
+        "clientName": "ТОВ \"Пекарня\""
+      }
+    },
+    "comment": "нал",
+    "managerFullName": "Андрій Бублик",
+    "orderWeight": 300.00
+  },
+  {
+    "id": 2,
+    "refKey": "03grande-0000-0000-0000-000000000000",
+    "orderNumber": "426457",
+    "products": [
+      {
+        "productName": "4695 Фарба харчова зелена",
+        "amount": 10,
+        "storeName": "Склад №1",
+        "unitWeight": 10.0,
+        "totalProductWeight": 100.00
+      }
+    ],
+    "addressExternal": {
+      "orderAddressId": {
+        "orderAddress": "м. Київ, вул. Молодогвардійська, 22, оф. 35",
+        "clientName": "ТОВ \"Пекарня\""
+      }
+    },
+    "comment": "бн",
+    "managerFullName": "Іван Шугай",
+    "orderWeight": 100.00
+  },
+  {
+    "id": 3,
+    "refKey": "04grande-0000-0000-0000-000000000000",
+    "orderNumber": "986453",
+    "products": [
+      {
+        "productName": "8452 Масло 1й гатунок",
+        "amount": 1,
+        "storeName": "Склад №1",
+        "unitWeight": 25.00,
+        "totalProductWeight": 25.00
+      },
+      {
+        "productName": "8795 Мука екстра",
+        "amount": 9,
+        "storeName": "Склад №1",
+        "unitWeight": 50,
+        "totalProductWeight": 450.00
+      }
+    ],
+    "addressExternal": {
+      "orderAddressId": {
+        "orderAddress": "м. Київ, вул. Молодогвардійська, 22, оф. 35",
+        "clientName": "ТОВ \"Пекарня\""
+      }
+    },
+    "comment": "нал",
+    "managerFullName": "Петро Коваленко",
+    "orderWeight": 475.00
+  }
+]

--- a/goods-partner-backend/src/test/resources/datasets/delivery/delivery-dataset.json
+++ b/goods-partner-backend/src/test/resources/datasets/delivery/delivery-dataset.json
@@ -62,5 +62,5 @@
       "frozen": false
     }
   ],
-  "carLoads": []
+  "productsShipping": []
 }


### PR DESCRIPTION
Example of view of ProductShippingDto -> 

{
	"article": "8795 Мука екстра",
	"totalAmount": 18,
	"totalWeight": 900.0,
	"productLoadDtos": [
		{
			"orderNumber": "986453",
			"car": "Mercedes Vito (AA 2222 CT)",
			"amount": 9,
			"weight": 50.0,
			"totalWeight": 450.0
		},
		{
			"orderNumber": "986453",
			"car": "Mercedes Sprinter (AA 3333 CT)",
			"amount": 9,
			"weight": 50.0,
			"totalWeight": 450.0
		}
	]
}